### PR TITLE
增強計算機自然語言解析

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+logs/
+*.log
+

--- a/UpdateLog.md
+++ b/UpdateLog.md
@@ -24,3 +24,23 @@
 ### [v.0.2.1]
 ## Fix
 - 更新測試檔案名稱，讓其更符合測試內容
+
+### [v.0.3.0]
+## New
+- 新增計算機工具(計算基本、進階與高等數學功能)
+- 增加 HTTP 介面以接受運算請求
+## Fix
+- 修正 UpdateLog 檔案結尾異常字串
+
+### [v.0.3.1]
+## Change
+- 移除計算機 HTTP 介面
+- 新增自然語言解析模組，提供 evaluateNaturalLanguage 函式
+- 更新 CalculatorTest.js 測試自然語言運算
+
+### [v.0.4.0]
+## New
+- 擴充自然語言解析器，支援更多中英文運算敘述
+- 新增 formatter 模組，可將運算式轉為通用符號表示
+- calculator 模組增加 naturalLanguageToSymbol 與 formatExpression 函式
+- 測試腳本記錄運算結果與符號表示

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,197 @@
+{
+  "name": "demon",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "demon",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "mathjs": "^14.5.3",
+        "tar": "^7.4.3"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/complex.js": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.2.tgz",
+      "integrity": "sha512-qtx7HRhPGSCBtGiST4/WGHuW+zeaND/6Ld+db6PbrulIB1i2Ev/2UPiqcmpQNPSyfBKraC0EOvOKCB5dGZKt3g==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
+      "license": "MIT"
+    },
+    "node_modules/fraction.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.2.2.tgz",
+      "integrity": "sha512-uXBDv5knpYmv/2gLzWQ5mBHGBRk9wcKTeWu6GLTUEQfjCxO09uM/mHDrojlL+Q1mVGIIFo149Gba7od1XPgSzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "license": "MIT"
+    },
+    "node_modules/mathjs": {
+      "version": "14.5.3",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-14.5.3.tgz",
+      "integrity": "sha512-srHhiZwFPUjHuRywRG/+5xWUNcQJsDBNMYaSu7zEN+th6BB2TkUmBkIc2cpdDqtgu40Q7DneAsFmyzo8q3ugmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "license": "MIT"
+    },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "license": "MIT"
+    },
+    "node_modules/typed-function": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.1.tgz",
+      "integrity": "sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "demon",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "node test/CalculatorTest.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "mathjs": "^14.5.3",
+    "tar": "^7.4.3"
+  }
+}

--- a/src/tools/calculator/advanced.js
+++ b/src/tools/calculator/advanced.js
@@ -1,0 +1,25 @@
+const math = require('mathjs');
+
+// 進階運算，提供次方、平方根與三角函數等
+module.exports = {
+  pow(base, exponent) {
+    return math.pow(base, exponent);
+  },
+
+  sqrt(value) {
+    if (value < 0) throw new Error('無法對負數取平方根');
+    return math.sqrt(value);
+  },
+
+  sin(value) {
+    return math.sin(value);
+  },
+
+  cos(value) {
+    return math.cos(value);
+  },
+
+  tan(value) {
+    return math.tan(value);
+  }
+};

--- a/src/tools/calculator/arithmetic.js
+++ b/src/tools/calculator/arithmetic.js
@@ -1,0 +1,21 @@
+const math = require('mathjs');
+
+// 基本運算功能，提供加減乘除
+module.exports = {
+  add(a, b) {
+    return math.add(a, b);
+  },
+
+  subtract(a, b) {
+    return math.subtract(a, b);
+  },
+
+  multiply(a, b) {
+    return math.multiply(a, b);
+  },
+
+  divide(a, b) {
+    if (b === 0) throw new Error('除數不可為 0');
+    return math.divide(a, b);
+  }
+};

--- a/src/tools/calculator/calculus.js
+++ b/src/tools/calculator/calculus.js
@@ -1,0 +1,32 @@
+const math = require('mathjs');
+
+// 數值積分：使用 Simpson 法近似
+function integrate(expr, variable, a, b, n = 1000) {
+  const compiled = math.compile(expr);
+  const h = (b - a) / n;
+  let sum = compiled.evaluate({ [variable]: a }) + compiled.evaluate({ [variable]: b });
+  for (let i = 1; i < n; i++) {
+    const x = a + i * h;
+    const weight = i % 2 === 0 ? 2 : 4;
+    sum += weight * compiled.evaluate({ [variable]: x });
+  }
+  return (h / 3) * sum;
+}
+
+// 數值極限：從左右逼近
+function limit(expr, variable, value, epsilon = 1e-7) {
+  const compiled = math.compile(expr);
+  const left = compiled.evaluate({ [variable]: value - epsilon });
+  const right = compiled.evaluate({ [variable]: value + epsilon });
+  if (Math.abs(left - right) < 1e-6) return (left + right) / 2;
+  throw new Error('左右極限不相等');
+}
+
+module.exports = {
+  derivative(expr, variable) {
+    return math.derivative(expr, variable).toString();
+  },
+
+  integrate,
+  limit
+};

--- a/src/tools/calculator/formatter.js
+++ b/src/tools/calculator/formatter.js
@@ -1,0 +1,52 @@
+const math = require('mathjs');
+
+/**
+ * 將運算式轉換為通用符號表示，方便文字或 LLMS 使用
+ * 會嘗試解析 derivative、integrate、limit 等特殊函式
+ * 其餘則交由 math.js 解析並以 toString 輸出
+ * @param {string} expression
+ * @returns {string} 轉換後的符號字串
+ */
+function formatExpression(expression) {
+  if (typeof expression !== 'string') {
+    throw new Error('運算式必須為字串');
+  }
+
+  let match;
+
+  // derivative(expr, variable)
+  match = expression.match(/^derivative\((.*),(.*)\)$/);
+  if (match) {
+    const expr = match[1].trim();
+    const variable = match[2].trim();
+    return `d/d${variable} (${expr})`;
+  }
+
+  // integrate(expr, variable, a, b)
+  match = expression.match(/^integrate\((.*),(.*),(.*),(.*)\)$/);
+  if (match) {
+    const expr = match[1].trim();
+    const variable = match[2].trim();
+    const a = match[3].trim();
+    const b = match[4].trim();
+    return `∫_${a}^${b} ${expr} d${variable}`;
+  }
+
+  // limit(expr, variable, value)
+  match = expression.match(/^limit\((.*),(.*),(.*)\)$/);
+  if (match) {
+    const expr = match[1].trim();
+    const variable = match[2].trim();
+    const value = match[3].trim();
+    return `lim_{${variable}->${value}} ${expr}`;
+  }
+
+  try {
+    const node = math.parse(expression);
+    return node.toString();
+  } catch (err) {
+    throw new Error('無法解析運算式');
+  }
+}
+
+module.exports = { formatExpression };

--- a/src/tools/calculator/index.js
+++ b/src/tools/calculator/index.js
@@ -1,0 +1,65 @@
+const arithmetic = require('./arithmetic');
+const advanced = require('./advanced');
+const calculus = require('./calculus');
+const { parseNaturalLanguage } = require('./nlp');
+const { formatExpression } = require('./formatter');
+const math = require('mathjs');
+
+// 利用正規表示式解析特殊函式呼叫
+function evaluateExpression(expression) {
+  if (typeof expression !== 'string') throw new Error('運算式必須為字串');
+
+  // derivative(expr, variable)
+  let match = expression.match(/^derivative\((.*),(.*)\)$/);
+  if (match) {
+    const expr = match[1].trim();
+    const variable = match[2].trim();
+    return calculus.derivative(expr, variable);
+  }
+
+  // integrate(expr, variable, a, b)
+  match = expression.match(/^integrate\((.*),(.*),(.*),(.*)\)$/);
+  if (match) {
+    const expr = match[1].trim();
+    const variable = match[2].trim();
+    const a = parseFloat(match[3]);
+    const b = parseFloat(match[4]);
+    if (Number.isNaN(a) || Number.isNaN(b)) throw new Error('積分上下限必須為數字');
+    return calculus.integrate(expr, variable, a, b);
+  }
+
+  // limit(expr, variable, value)
+  match = expression.match(/^limit\((.*),(.*),(.*)\)$/);
+  if (match) {
+    const expr = match[1].trim();
+    const variable = match[2].trim();
+    const value = parseFloat(match[3]);
+    if (Number.isNaN(value)) throw new Error('極限值必須為數字');
+    return calculus.limit(expr, variable, value);
+  }
+
+  // 其他直接交給 mathjs evaluate
+  return math.evaluate(expression);
+}
+
+// 解析自然語言並計算結果
+function evaluateNaturalLanguage(text) {
+  const expr = parseNaturalLanguage(text);
+  return evaluateExpression(expr);
+}
+
+// 解析自然語言後轉為通用符號表示，方便 LLM 取得結構化運算式
+function naturalLanguageToSymbol(text) {
+  const expr = parseNaturalLanguage(text);
+  return formatExpression(expr);
+}
+
+module.exports = {
+  ...arithmetic,
+  ...advanced,
+  ...calculus,
+  evaluateExpression,
+  evaluateNaturalLanguage,
+  formatExpression,
+  naturalLanguageToSymbol
+};

--- a/src/tools/calculator/nlp.js
+++ b/src/tools/calculator/nlp.js
@@ -1,0 +1,73 @@
+// 無需額外套件即可進行簡易的自然語言解析
+// 主要將常見的中文與英文敘述轉為標準數學運算式
+function parseNaturalLanguage(text) {
+  if (typeof text !== 'string' || text.trim() === '') {
+    throw new Error('輸入必須為非空字串');
+  }
+
+  // 去除前後空白，方便後續比對
+  const str = text.trim();
+
+  let match;
+
+  // 微分：支援「微分 x^2 對 x」、「求導 x^2 針對 x」等寫法
+  match = str.match(/(?:微分|求導)\s*(.+)\s*(?:對|針對)\s*(\w+)/i);
+  if (!match) {
+    match = str.match(/derivative\s+of\s+(.+)\s+with\s+respect\s+to\s+(\w+)/i);
+  }
+  if (match) {
+    const expr = match[1].trim();
+    const variable = match[2].trim();
+    return `derivative(${expr},${variable})`;
+  }
+
+  // 積分：支援「積分 sin(x) 對 x 從 0 到 1」或英文類似敘述
+  match = str.match(/(?:積分|求積)\s*(.+)\s*(?:對|關於)\s*(\w+)\s*(?:從|由)\s*(.+)\s*(?:到|至)\s*(.+)/i);
+  if (!match) {
+    match = str.match(/integrate\s*(.+)\s*with\s*respect\s*to\s*(\w+)\s*from\s*(.+)\s*to\s*(.+)/i);
+  }
+  if (match) {
+    const expr = match[1].trim();
+    const variable = match[2].trim();
+    const a = match[3].trim();
+    const b = match[4].trim();
+    return `integrate(${expr},${variable},${a},${b})`;
+  }
+
+  // 極限：處理中英文各種表達
+  match = str.match(/(?:極限|limit)\s*(.+)\s*(?:當|as)\s*(\w+)\s*(?:趨近|approaches?)\s*(.+)/i);
+  if (match) {
+    const expr = match[1].trim();
+    const variable = match[2].trim();
+    const value = match[3].trim();
+    return `limit(${expr},${variable},${value})`;
+  }
+
+  // 加減乘除與其他基本運算
+  match = str.match(/(-?\d+(?:\.\d+)?)\s*(?:plus|加|加上|和|與)\s*(-?\d+(?:\.\d+)?)/i);
+  if (match) return `${match[1]} + ${match[2]}`;
+
+  match = str.match(/(-?\d+(?:\.\d+)?)\s*(?:minus|減|減去)\s*(-?\d+(?:\.\d+)?)/i);
+  if (match) return `${match[1]} - ${match[2]}`;
+
+  match = str.match(/(-?\d+(?:\.\d+)?)\s*(?:times|乘|乘以|乘上|multiplied by)\s*(-?\d+(?:\.\d+)?)/i);
+  if (match) return `${match[1]} * ${match[2]}`;
+
+  match = str.match(/(-?\d+(?:\.\d+)?)\s*(?:divided by|除以|除|比)\s*(-?\d+(?:\.\d+)?)/i);
+  if (match) return `${match[1]} / ${match[2]}`;
+
+  // 平方根：支援「square root of 4」、「4 的平方根」、「開根號 4」
+  match = str.match(/(?:square root of|平方根|開根號)\s*(-?\d+(?:\.\d+)?)/i);
+  if (match) return `sqrt(${match[1]})`;
+
+  // 次方：例如「2 的 3 次方」、「2 raised to the power of 3」、「2 的平方」
+  match = str.match(/(-?\d+(?:\.\d+)?)\s*(?:raised to the power of|的?\s*次方)\s*(-?\d+(?:\.\d+)?)/i);
+  if (match) return `pow(${match[1]},${match[2]})`;
+  match = str.match(/(-?\d+(?:\.\d+)?)\s*(?:的)?\s*平方/i);
+  if (match) return `pow(${match[1]},2)`;
+
+  // 無法解析時，直接回傳原文字串（交由 math.js 處理）
+  return str;
+}
+
+module.exports = { parseNaturalLanguage };

--- a/test/CalculatorTest.js
+++ b/test/CalculatorTest.js
@@ -1,0 +1,30 @@
+const { evaluateNaturalLanguage, naturalLanguageToSymbol } = require('../src/tools/calculator');
+const Logger = require('../src/core/logger');
+
+const logger = new Logger('calculator-test.log');
+
+(async () => {
+  try {
+  logger.info('自然語言加法測試: 2 加 3');
+  const a = evaluateNaturalLanguage('2 加 3');
+  logger.info(`結果: ${a}`);
+  logger.info('符號表示: ' + naturalLanguageToSymbol('2 加 3'));
+
+  logger.info('自然語言微分測試: 微分 x^2 對 x');
+  const d = evaluateNaturalLanguage('微分 x^2 對 x');
+  logger.info(`結果: ${d}`);
+  logger.info('符號表示: ' + naturalLanguageToSymbol('微分 x^2 對 x'));
+
+  logger.info('自然語言積分測試: 積分 sin(x) 對 x 從 0 到 3.14159');
+  const i = evaluateNaturalLanguage('積分 sin(x) 對 x 從 0 到 3.14159');
+  logger.info(`結果: ${i}`);
+  logger.info('符號表示: ' + naturalLanguageToSymbol('積分 sin(x) 對 x 從 0 到 3.14159'));
+
+  logger.info('自然語言極限測試: 極限 sin(x)/x 當 x 趨近 0');
+  const l = evaluateNaturalLanguage('極限 sin(x)/x 當 x 趨近 0');
+  logger.info(`結果: ${l}`);
+  logger.info('符號表示: ' + naturalLanguageToSymbol('極限 sin(x)/x 當 x 趨近 0'));
+  } catch (err) {
+    logger.error('測試失敗', err);
+  }
+})();


### PR DESCRIPTION
## Summary
- 強化 nlp.js 規則，支援更多中英文數學敘述
- 新增 formatter 模組，將運算式轉為通用符號
- calculator 匯出 `formatExpression` 與 `naturalLanguageToSymbol`
- 測試腳本紀錄符號表示
- 更新 UpdateLog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bfc43ad70832f92a0c5a7d7d6df7a