### PR TITLE
新增插件測試並修正路徑

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -1,10 +1,10 @@
 ## ASR
-[ ] 更改setting以及架構使其符合plugin要求
-[ ] 測試檔案
+[x] 更改setting以及架構使其符合plugin要求
+[x] 測試檔案
 
 ## TTS
-[ ] 更改setting以及架構使其符合plugin要求
-[ ] 測試檔案
+[x] 更改setting以及架構使其符合plugin要求
+[x] 測試檔案
 
 ## 小惡魔的對話設定
 [ ] 對<>的前綴附加詞的說明設定

--- a/UpdateLog.md
+++ b/UpdateLog.md
@@ -49,3 +49,16 @@
 ### [v.0.5a]
 ## New
 - 新增ASR和TTS插件，不過是還未依照插件規範設計的，等待後續v0.5版修改
+
+### [v.0.5]
+## New
+- 將 ASR 與 TTS 插件重構為符合插件規範的架構，修正路徑並補充錯誤處理
+- 新增 SpeechBroker 插件，負責將 Demon 串流輸出轉送至 TTS
+## Fix
+- 修正 ToDo 與 UpdateLog 尾端誤植字串
+
+### [v.0.5.1]
+## Test
+- 新增 ASR、TTS 與 SpeechBroker 插件測試，模擬 PythonShell 與事件流程
+## Fix
+- 修正插件策略檔引用 utils 路徑錯誤

--- a/__test__/asrPlugin.test.js
+++ b/__test__/asrPlugin.test.js
@@ -1,0 +1,76 @@
+const path = require('path');
+const { EventEmitter } = require('events');
+
+// 模擬 TalkToDemon
+jest.mock('../src/core/TalkToDemon.js', () => {
+  const { EventEmitter } = require('events');
+  const t = new EventEmitter();
+  t.closeGate = jest.fn();
+  t.openGate = jest.fn();
+  t.manualAbort = jest.fn();
+  t.talk = jest.fn();
+  t.getState = jest.fn(() => 'busy');
+  t.getGateState = jest.fn(() => 'open');
+  return t;
+}, { virtual: true });
+const talkerPath = require.resolve('../src/core/TalkToDemon.js');
+const talkerMock = require(talkerPath);
+const gateState = talkerMock.getGateState;
+
+// 模擬 PluginsManager (僅用於 sendToTTS 時查詢狀態，但 ASR 目前未使用)
+jest.mock('../src/core/pluginsManager.js', () => ({
+  getPluginState: jest.fn(async () => 1),
+  send: jest.fn(),
+}), { virtual: true });
+const pmPath = require.resolve('../src/core/pluginsManager.js');
+const pmMock = require(pmPath);
+
+// 模擬 python-shell
+jest.mock('python-shell', () => {
+  const { EventEmitter } = require('events');
+  return {
+    PythonShell: jest.fn().mockImplementation((script, options) => {
+      const emitter = new EventEmitter();
+      emitter.script = script;
+      emitter.options = options;
+      emitter.terminated = false;
+      emitter.end = (cb) => { emitter.terminated = true; cb && cb(null, 0, null); };
+      return emitter;
+    })
+  };
+}, { virtual: true });
+
+const { PythonShell } = require('python-shell');
+const asrLocal = require('../src/plugins/asr/strategies/local');
+
+describe('ASR 本地策略', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await asrLocal.offline();
+  });
+
+  test('online 會啟動 PythonShell 並處理事件', async () => {
+    await asrLocal.online({ deviceId: '2', sliceDuration: '3' });
+    expect(PythonShell).toHaveBeenCalled();
+
+    const inst = PythonShell.mock.results[0].value;
+    inst.emit('message', 'asr_start');
+    expect(talkerMock.closeGate).toHaveBeenCalled();
+
+    inst.emit('message', 'asr_ignore');
+    expect(talkerMock.openGate).toHaveBeenCalled();
+
+    gateState.mockReturnValue('close');
+    inst.emit('message', JSON.stringify({ text: '測試句子' }));
+    expect(talkerMock.manualAbort).toHaveBeenCalled();
+    expect(talkerMock.talk).toHaveBeenCalledWith('爸爸', '測試句子', expect.any(Object));
+  });
+
+  test('offline 會結束 PythonShell', async () => {
+    await asrLocal.online({});
+    const inst = PythonShell.mock.results[0].value;
+    const endSpy = jest.spyOn(inst, 'end');
+    await asrLocal.offline();
+    expect(endSpy).toHaveBeenCalled();
+  });
+});

--- a/__test__/speechBroker.test.js
+++ b/__test__/speechBroker.test.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const { EventEmitter } = require('events');
+
+// 模擬 TalkToDemon
+jest.mock('../src/core/TalkToDemon.js', () => {
+  const { EventEmitter } = require('events');
+  const t = new EventEmitter();
+  t.on = jest.fn(t.on.bind(t));
+  t.off = jest.fn(t.off.bind(t));
+  return Object.assign(t, {
+    closeGate: jest.fn(),
+    openGate: jest.fn(),
+    manualAbort: jest.fn(),
+    talk: jest.fn(),
+    getState: jest.fn(() => 'busy'),
+    getGateState: jest.fn(() => 'open')
+  });
+}, { virtual: true });
+const talkerPath = require.resolve('../src/core/TalkToDemon.js');
+const talkerMock = require(talkerPath);
+
+// 模擬 PluginsManager
+jest.mock('../src/core/pluginsManager.js', () => ({
+  send: jest.fn(),
+  getPluginState: jest.fn(async () => 1)
+}), { virtual: true });
+const pmPath = require.resolve('../src/core/pluginsManager.js');
+const pmMock = require(pmPath);
+
+const brokerLocal = require('../src/plugins/speechBroker/strategies/local');
+
+describe('SpeechBroker 本地策略', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await brokerLocal.offline();
+  });
+
+  test('online 監聽 data 並轉送至 TTS', async () => {
+    await brokerLocal.online();
+    expect(talkerMock.on).toHaveBeenCalledWith('data', expect.any(Function));
+    const handler = talkerMock.on.mock.calls.find(c => c[0] === 'data')[1];
+    talkerMock.emit('data', '你好');
+    talkerMock.emit('data', '。');
+    await new Promise(process.nextTick);
+    expect(pmMock.send).toHaveBeenCalledWith('tts', '你好。');
+  });
+
+  test('offline 會移除監聽', async () => {
+    await brokerLocal.online();
+    await brokerLocal.offline();
+    expect(talkerMock.off).toHaveBeenCalled();
+  });
+});

--- a/__test__/ttsPlugin.test.js
+++ b/__test__/ttsPlugin.test.js
@@ -1,0 +1,45 @@
+const { EventEmitter } = require('events');
+
+// 模擬 python-shell
+jest.mock('python-shell', () => {
+  const { EventEmitter } = require('events');
+  return {
+    PythonShell: jest.fn().mockImplementation((script, options) => {
+      const emitter = new EventEmitter();
+      emitter.script = script;
+      emitter.options = options;
+      emitter.terminated = false;
+      emitter.stdin = true;
+      emitter.send = jest.fn();
+      emitter.end = (cb) => { emitter.terminated = true; cb && cb(null, 0, null); };
+      return emitter;
+    })
+  };
+}, { virtual: true });
+
+const { PythonShell } = require('python-shell');
+const ttsLocal = require('../src/plugins/tts/strategies/local');
+
+describe('TTS 本地策略', () => {
+  beforeEach(async () => { jest.clearAllMocks(); await ttsLocal.offline(); });
+
+  test('online 會啟動 PythonShell', async () => {
+    await ttsLocal.online({ pythonPath: 'p' });
+    expect(PythonShell).toHaveBeenCalled();
+  });
+
+  test('send 會透過 PythonShell 傳遞資料', async () => {
+    await ttsLocal.online({});
+    const inst = PythonShell.mock.results[0].value;
+    ttsLocal.send('hello');
+    expect(inst.send).toHaveBeenCalledWith('hello');
+  });
+
+  test('offline 會結束 PythonShell', async () => {
+    await ttsLocal.online({});
+    const inst = PythonShell.mock.results[0].value;
+    const endSpy = jest.spyOn(inst, 'end');
+    await ttsLocal.offline();
+    expect(endSpy).toHaveBeenCalled();
+  });
+});

--- a/src/plugins/asr/index.js
+++ b/src/plugins/asr/index.js
@@ -1,0 +1,67 @@
+const local = require('./strategies/local');
+const Logger = require('../../utils/logger');
+const logger = new Logger('ASR');
+
+// 目前僅提供 local 策略
+let strategy = null;
+
+module.exports = {
+  // 更新策略，依照需求載入對應實作
+  async updateStrategy() {
+    logger.info('ASR 插件策略更新中...');
+    strategy = local;
+    logger.info('ASR 插件策略已載入');
+  },
+
+  // 啟動 ASR
+  async online(options) {
+    if (!strategy) await this.updateStrategy();
+    try {
+      return await strategy.online(options);
+    } catch (e) {
+      logger.error('[ASR] online 發生錯誤: ' + e);
+      throw e;
+    }
+  },
+
+  // 關閉 ASR
+  async offline() {
+    if (!strategy) await this.updateStrategy();
+    try {
+      return await strategy.offline();
+    } catch (e) {
+      logger.error('[ASR] offline 發生錯誤: ' + e);
+      throw e;
+    }
+  },
+
+  // 重啟 ASR
+  async restart(options) {
+    if (!strategy) await this.updateStrategy();
+    try {
+      return await strategy.restart(options);
+    } catch (e) {
+      logger.error('[ASR] restart 發生錯誤: ' + e);
+      throw e;
+    }
+  },
+
+  // 取得狀態
+  async state() {
+    if (!strategy) await this.updateStrategy();
+    try {
+      return await strategy.state();
+    } catch (e) {
+      logger.error('[ASR] state 查詢錯誤: ' + e);
+      return -1;
+    }
+  },
+
+  // 選用函式，目前策略未提供
+  async send(data) {
+    if (!strategy || typeof strategy.send !== 'function') {
+      return false;
+    }
+    return strategy.send(data);
+  }
+};

--- a/src/plugins/asr/strategies/local/index.js
+++ b/src/plugins/asr/strategies/local/index.js
@@ -2,8 +2,9 @@ const path = require("path");
 const { PythonShell } = require("python-shell");
 
 // 內部引入
-const talker = require("../../core/TalkToAngel.js");
-const logger = require("../../core/logger.js");
+// 調整路徑以符合最新的專案架構
+const talker = require("../../../../core/TalkToDemon.js");
+const logger = require("../../../../utils/logger.js");
 
 let processRef = null;
 const Logger = new logger("asr.log");
@@ -26,7 +27,8 @@ function endPythonShell(shell) {
 module.exports = {
   name: "ASR",
   async online(options = {}) {
-    const scriptPath = path.resolve(__dirname, "index.py");
+    // Python 執行檔相對於此策略目錄上兩層
+    const scriptPath = path.resolve(__dirname, "..", "..", "index.py");
     const pyshell = new PythonShell(scriptPath, {
       pythonPath: "E:\system\whisperenv\Scripts\python.exe",
       args: [

--- a/src/plugins/speechBroker/index.js
+++ b/src/plugins/speechBroker/index.js
@@ -1,0 +1,58 @@
+const local = require('./strategies/local');
+const Logger = require('../../utils/logger');
+const logger = new Logger('SpeechBroker');
+
+let strategy = null;
+
+module.exports = {
+  // 更新策略，目前僅支援 local
+  async updateStrategy() {
+    logger.info('SpeechBroker 策略更新中...');
+    strategy = local;
+    logger.info('SpeechBroker 策略已載入');
+  },
+
+  // 啟動插件
+  async online(options) {
+    if (!strategy) await this.updateStrategy();
+    try {
+      return await strategy.online(options);
+    } catch (e) {
+      logger.error('[SpeechBroker] online 發生錯誤: ' + e);
+      throw e;
+    }
+  },
+
+  // 關閉插件
+  async offline() {
+    if (!strategy) await this.updateStrategy();
+    try {
+      return await strategy.offline();
+    } catch (e) {
+      logger.error('[SpeechBroker] offline 發生錯誤: ' + e);
+      throw e;
+    }
+  },
+
+  // 重啟插件
+  async restart(options) {
+    if (!strategy) await this.updateStrategy();
+    try {
+      return await strategy.restart(options);
+    } catch (e) {
+      logger.error('[SpeechBroker] restart 發生錯誤: ' + e);
+      throw e;
+    }
+  },
+
+  // 查詢狀態
+  async state() {
+    if (!strategy) await this.updateStrategy();
+    try {
+      return await strategy.state();
+    } catch (e) {
+      logger.error('[SpeechBroker] state 查詢錯誤: ' + e);
+      return -1;
+    }
+  },
+};

--- a/src/plugins/speechBroker/strategies/local/index.js
+++ b/src/plugins/speechBroker/strategies/local/index.js
@@ -1,0 +1,133 @@
+const talker = require('../../../../core/TalkToDemon.js');
+const Logger = require('../../../../utils/logger.js');
+const PM = require('../../../../core/pluginsManager.js');
+
+let buffer = '';
+let isOnline = false;
+// 儲存事件處理函式，便於 offline 時移除
+const handlers = {};
+
+// 建立 logger 實例，輸出至 speechBroker.log
+const logger = new Logger('speechBroker.log');
+
+// 中文標點轉換對照表（全形 → 半形）
+const PUNCTUATION_MAP = {
+  '。': '。',
+  '？': '?',
+  '！': '!',
+  '～': '~',
+  '♥': '', // 視為 emoji，移除
+};
+
+// 匹配中英文句尾符號（包含 emoji）
+const SENTENCE_ENDINGS = /[。！？?!~～♥\uFF01\uFF1F\u3002]/;
+
+// 移除表情標記，例如 (害羞)、(微笑)
+const EXPRESSION_PATTERN = /[\(（][^\)）]{1,10}[\)）]/g;
+
+/**
+ * 清理字串片段，去除表情並統一標點
+ * @param {string} chunk 原始片段
+ * @returns {string} 清理後結果
+ */
+function sanitizeChunk(chunk) {
+  // 去除 (表情)
+  const noExpression = chunk.replace(EXPRESSION_PATTERN, '');
+  // 替換標點（句號不變）
+  return noExpression.replace(SENTENCE_ENDINGS, (match) => PUNCTUATION_MAP[match] ?? match);
+}
+
+/**
+ * 將文字傳送至 TTS 插件
+ * @param {string} sentence
+ */
+async function sendToTTS(sentence) {
+  try {
+    if (await PM.getPluginState('tts') !== 1) {
+      logger.warn('[SpeechBroker] TTS 插件未上線，無法送出，狀態碼: ' + await PM.getPluginState('tts'));
+      logger.warn('[SpeechBroker] TTS 插件未上線，無法送出: ' + sentence);
+      return;
+    }
+    PM.send('tts', sentence);
+    logger.info('[SpeechBroker] 送出 TTS: ' + sentence);
+  } catch (e) {
+    logger.error('[SpeechBroker] TTS 輸出失敗: ' + e);
+  }
+}
+
+module.exports = {
+  name: 'speechBroker',
+
+  /** 啟動插件，監聽 TalkToDemon 串流輸出 */
+  async online(options = {}) {
+    if (isOnline) return;
+    isOnline = true;
+    buffer = '';
+
+    handlers.onData = async (chunk) => {
+      if (SENTENCE_ENDINGS.test(chunk)) {
+        const sentence = (buffer + chunk).trim();
+        const sanitized = sanitizeChunk(sentence);
+        if (sentence.length > 0) {
+          await sendToTTS(sanitized);
+        }
+        buffer = '';
+      } else {
+        buffer += chunk;
+      }
+    };
+    talker.on('data', handlers.onData);
+
+    handlers.onEnd = async () => {
+      if (buffer.trim().length > 0) {
+        await sendToTTS(buffer.trim() + '.');
+        logger.info('[SpeechBroker] 串流完成，餘句送出: ' + buffer.trim());
+        buffer = '';
+      }
+    };
+    talker.on('end', handlers.onEnd);
+
+    handlers.onAbort = async () => {
+      if (buffer.trim().length > 0) {
+        await sendToTTS(buffer.trim() + '.');
+        logger.info('[SpeechBroker] 中止輸出，餘句送出: ' + buffer.trim());
+        buffer = '';
+      }
+    };
+    talker.on('abort', handlers.onAbort);
+
+    handlers.onError = (err) => {
+      logger.error('[SpeechBroker] LLM 串流錯誤: ' + err);
+    };
+    talker.on('error', handlers.onError);
+
+    logger.info('[SpeechBroker] 插件已上線');
+  },
+
+  /** 關閉插件 */
+  async offline() {
+    if (!isOnline) return 0;
+    isOnline = false;
+    buffer = '';
+    // 移除所有事件監聽，避免離線後仍接收資料
+    talker.off('data', handlers.onData);
+    talker.off('end', handlers.onEnd);
+    talker.off('abort', handlers.onAbort);
+    talker.off('error', handlers.onError);
+    Object.keys(handlers).forEach(k => delete handlers[k]);
+    logger.info('[SpeechBroker] 插件已下線');
+    return 0;
+  },
+
+  /** 重啟插件 */
+  async restart(options) {
+    await this.offline();
+    await new Promise(r => setTimeout(r, 300));
+    await this.online(options);
+  },
+
+  /** 回傳插件狀態 */
+  async state() {
+    return isOnline ? 1 : 0;
+  }
+};

--- a/src/plugins/tts/index.js
+++ b/src/plugins/tts/index.js
@@ -1,0 +1,66 @@
+const local = require('./strategies/local');
+const Logger = require('../../utils/logger');
+const logger = new Logger('TTS');
+
+let strategy = null;
+
+module.exports = {
+  // 更新策略
+  async updateStrategy() {
+    logger.info('TTS 插件策略更新中...');
+    strategy = local;
+    logger.info('TTS 插件策略已載入');
+  },
+
+  // 啟動 TTS
+  async online(options) {
+    if (!strategy) await this.updateStrategy();
+    try {
+      return await strategy.online(options);
+    } catch (e) {
+      logger.error('[TTS] online 發生錯誤: ' + e);
+      throw e;
+    }
+  },
+
+  // 關閉 TTS
+  async offline() {
+    if (!strategy) await this.updateStrategy();
+    try {
+      return await strategy.offline();
+    } catch (e) {
+      logger.error('[TTS] offline 發生錯誤: ' + e);
+      throw e;
+    }
+  },
+
+  // 重啟 TTS
+  async restart(options) {
+    if (!strategy) await this.updateStrategy();
+    try {
+      return await strategy.restart(options);
+    } catch (e) {
+      logger.error('[TTS] restart 發生錯誤: ' + e);
+      throw e;
+    }
+  },
+
+  // 查詢狀態
+  async state() {
+    if (!strategy) await this.updateStrategy();
+    try {
+      return await strategy.state();
+    } catch (e) {
+      logger.error('[TTS] state 查詢錯誤: ' + e);
+      return -1;
+    }
+  },
+
+  // 選用函式
+  async send(data) {
+    if (!strategy || typeof strategy.send !== 'function') {
+      return false;
+    }
+    return strategy.send(data);
+  }
+};

--- a/src/plugins/tts/strategies/local/index.js
+++ b/src/plugins/tts/strategies/local/index.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const { PythonShell } = require("python-shell");
-const logger = require("../../core/logger.js");
+// 更新路徑至新的 utils 位置
+const logger = require("../../../../utils/logger.js");
 
 let processRef = null;
 const Logger = new logger("tts.log");
@@ -14,7 +15,8 @@ module.exports = {
       Logger.info("[TTS] 已啟動，略過重複啟動");
       return;
     }
-    const scriptPath = path.resolve(__dirname, "index.py");
+    // Python 腳本位於兩層上層
+    const scriptPath = path.resolve(__dirname, "..", "..", "index.py");
     processRef = new PythonShell(scriptPath, {
       pythonPath: options.pythonPath || "E:\system\f5ttsenv\Scripts\python.exe",
       args: [


### PR DESCRIPTION
## Summary
- 補充 ASR、TTS 與 SpeechBroker 插件測試
- 修正三個插件策略檔引入 utils 的相對路徑
- 更新更新紀錄至 v0.5.1

## Testing
- `npm install`
- `npm test` *(部分測試因缺乏依賴及執行檔仍然失敗)*

------
https://chatgpt.com/codex/tasks/task_e_6872b3782828832f8c092efc10466b3c