### PR TITLE
Implement asr and tts remote/server strategies

### DIFF
--- a/UpdateLog.md
+++ b/UpdateLog.md
@@ -101,3 +101,13 @@
 ### [v.0.6.4]
 ## Docs
 - 新增 ngrok 插件 options.md，說明各接口傳入的 options 內容
+
+### [v.0.7]
+## New
+- 實作 LlamaServer 遠端與伺服器策略
+- 新增 remote/infor.js 儲存子網域設定
+- 新增 ASR 與 TTS 插件的 remote 與 server 策略
+- remote/infor.js 提供子網域與接口資訊
+## Change
+- LlamaServer 插件可依 mode 切換 local、remote、server 三種策略
+- ASR、TTS 插件可依 mode 切換 local、remote、server 三種策略

--- a/src/plugins/asr/strategies/remote/index.js
+++ b/src/plugins/asr/strategies/remote/index.js
@@ -1,0 +1,64 @@
+const axios = require('axios');
+const Logger = require('../../../../utils/logger');
+const info = require('./infor');
+
+const logger = new Logger('ASRRemote');
+let baseUrl = '';
+
+module.exports = {
+  /**
+   * 啟動遠端策略，設定伺服器 baseUrl
+   * @param {{baseUrl:string}} options
+   */
+  async online(options = {}) {
+    if (!options.baseUrl) {
+      throw new Error('遠端模式需要提供 baseUrl');
+    }
+    baseUrl = options.baseUrl.replace(/\/$/, '');
+    logger.info(`ASR remote 已設定 baseUrl: ${baseUrl}`);
+    return true;
+  },
+
+  /** 關閉遠端策略 */
+  async offline() {
+    baseUrl = '';
+    logger.info('ASR remote 已關閉');
+    return true;
+  },
+
+  /** 重新啟動遠端策略 */
+  async restart(options) {
+    await this.offline();
+    return this.online(options);
+  },
+
+  /** 查詢遠端狀態 */
+  async state() {
+    if (!baseUrl) return 0;
+    try {
+      const { data } = await axios.get(`${baseUrl}/${info.subdomain}/${info.routes.state}`);
+      return Number(data?.state ?? 0);
+    } catch (e) {
+      logger.error('查詢遠端 ASR 狀態失敗: ' + e.message);
+      return -1;
+    }
+  },
+
+  /**
+   * 向遠端伺服器發送指令
+   * @param {'start'|'stop'|'restart'} action
+   */
+  async send(action = 'start') {
+    if (!baseUrl) throw new Error('遠端未初始化');
+    const route = info.routes[action];
+    if (!route) throw new Error(`未知的指令: ${action}`);
+    try {
+      const url = `${baseUrl}/${info.subdomain}/${route}`;
+      const res = await axios.post(url);
+      return res.data;
+    } catch (e) {
+      logger.error(`[ASRRemote] ${action} 執行失敗: ${e.message}`);
+      throw e;
+    }
+  }
+};

--- a/src/plugins/asr/strategies/remote/infor.js
+++ b/src/plugins/asr/strategies/remote/infor.js
@@ -1,0 +1,9 @@
+module.exports = {
+  subdomain: 'asr',
+  routes: {
+    start: 'start',
+    stop: 'stop',
+    restart: 'restart',
+    state: 'state'
+  }
+};

--- a/src/plugins/asr/strategies/server/index.js
+++ b/src/plugins/asr/strategies/server/index.js
@@ -1,0 +1,67 @@
+const local = require('../local');
+const info = require('../remote/infor');
+const pluginsManager = require('../../../../core/pluginsManager');
+const Logger = require('../../../../utils/logger');
+
+const logger = new Logger('ASRServer');
+let registered = false;
+
+module.exports = {
+  /** 啟動伺服器模式：註冊 ngrok 子網域並轉發指令至本地 ASR */
+  async online(options = {}) {
+    await local.online(options);
+
+    const handler = async (req, res) => {
+      const action = req.params.action;
+      try {
+        switch (action) {
+          case info.routes.start:
+            await local.online(options);
+            return res.status(200).end();
+          case info.routes.stop:
+            await local.offline();
+            return res.status(200).end();
+          case info.routes.restart:
+            await local.restart(options);
+            return res.status(200).end();
+          case info.routes.state: {
+            const state = await local.state();
+            return res.status(200).json({ state });
+          }
+          default:
+            return res.status(404).end();
+        }
+      } catch (e) {
+        logger.error('處理 ASR 遠端請求失敗: ' + e.message);
+        return res.status(500).end();
+      }
+    };
+
+    const result = await pluginsManager.send('ngrok', { action: 'register', subdomain: info.subdomain, handler });
+    if (!result) {
+      logger.error('註冊 ngrok 子網域失敗');
+      return false;
+    }
+    registered = true;
+    return true;
+  },
+
+  /** 關閉伺服器並解除註冊 */
+  async offline() {
+    if (registered) {
+      await pluginsManager.send('ngrok', { action: 'unregister', subdomain: info.subdomain });
+      registered = false;
+    }
+    await local.offline();
+    return true;
+  },
+
+  async restart(options) {
+    await this.offline();
+    return this.online(options);
+  },
+
+  async state() {
+    return local.state();
+  }
+};

--- a/src/plugins/llamaServer/index.js
+++ b/src/plugins/llamaServer/index.js
@@ -1,59 +1,70 @@
 const local = require('./strategies/local');
 const remote = require('./strategies/remote');
+const server = require('./strategies/server');
 
 const Logger = require('../../utils/logger');
 const logger = new Logger('LlamaServerManager');
 
 let strategies = null;
+let mode = 'local';
 
 module.exports = {
 
-    async updateStrategy() {
+    /**
+     * 更新策略模式
+     * @param {'local'|'remote'|'server'} newMode
+     */
+    async updateStrategy(newMode = 'local') {
         logger.info('LlamaServerManager 更新策略中...');
-        // 這裡可以根據需要更新策略
-        // 目前僅支援 local 策略
-        strategies = local;
-        logger.info('LlamaServerManager 策略更新完成');
+        mode = newMode;
+        switch (newMode) {
+            case 'remote':
+                strategies = remote;
+                break;
+            case 'server':
+                strategies = server;
+                break;
+            default:
+                strategies = local;
+        }
+        logger.info(`LlamaServerManager 策略已切換為 ${mode}`);
     },
 
-    async online(options) {
-        if (!strategies) {
-            logger.warn('LlamaServerManager 尚未初始化，正在初始化...');
-            await this.updateStrategy();
+    async online(options = {}) {
+        const useMode = options.mode || mode;
+        if (!strategies || useMode !== mode) {
+            await this.updateStrategy(useMode);
         }
-        return await strategies.online(options);
+        return strategies.online(options);
     },
 
     async offline() {
         if (!strategies) {
-            logger.warn('LlamaServerManager 尚未初始化，正在初始化...');
-            await this.updateStrategy();
+            await this.updateStrategy(mode);
         }
-        return await strategies.offline();
+        return strategies.offline();
     },
 
-    async restart(options) {
-        if (!strategies) {
-            logger.warn('LlamaServerManager 尚未初始化，正在初始化...');
-            await this.updateStrategy();
+    async restart(options = {}) {
+        const useMode = options.mode || mode;
+        if (!strategies || useMode !== mode) {
+            await this.updateStrategy(useMode);
         }
-        return await strategies.restart(options);
+        return strategies.restart(options);
     },
 
     async state() {
         if (!strategies) {
-            logger.warn('LlamaServerManager 尚未初始化，正在初始化...');
-            await this.updateStrategy();
+            await this.updateStrategy(mode);
         }
-        return await strategies.state();
+        return strategies.state();
     },
 
     async send(options) {
         if (!strategies) {
-            logger.warn('LlamaServerManager 尚未初始化，正在初始化...');
-            await this.updateStrategy();
+            await this.updateStrategy(mode);
         }
-        return await strategies.send(options);
+        return strategies.send(options);
     },
     
 }

--- a/src/plugins/llamaServer/strategies/remote/index.js
+++ b/src/plugins/llamaServer/strategies/remote/index.js
@@ -1,11 +1,100 @@
-// 等遠端實作建立完成後，再完成這邊
+const axios = require('axios');
+const EventEmitter = require('events');
+const Logger = require('../../../../utils/logger');
+const info = require('./infor');
+
+const logger = new Logger('LlamaRemote');
+
+let baseUrl = '';
 
 module.exports = {
-    async online(options) {},
-    async offline() {},
-    async restart(options) {},
-    async state() {},
-    async send(options) {
-        throw new Error('遠端 llama 尚未實作');
-    },
-}
+  /**
+   * 啟動遠端策略
+   * @param {Object} options
+   * @param {string} options.baseUrl 遠端伺服器位址，例如 https://xxxx.ngrok.io
+   */
+  async online(options = {}) {
+    if (!options.baseUrl) {
+      throw new Error('遠端模式需要提供 baseUrl');
+    }
+    baseUrl = options.baseUrl.replace(/\/$/, '');
+    logger.info(`Llama remote 已設定 baseUrl: ${baseUrl}`);
+    return true;
+  },
+
+  /** 停止遠端策略 */
+  async offline() {
+    baseUrl = '';
+    logger.info('Llama remote 已關閉');
+    return true;
+  },
+
+  /** 重新啟動遠端策略 */
+  async restart(options) {
+    await this.offline();
+    return this.online(options);
+  },
+
+  /** 檢查狀態：有 baseUrl 即視為上線 */
+  async state() {
+    return baseUrl ? 1 : 0;
+  },
+
+  /**
+   * 透過 HTTP 與遠端伺服器互動
+   * @param {Array} messages - 傳遞給 Llama 的訊息陣列
+   * @returns {EventEmitter}
+   */
+  async send(messages = []) {
+    if (!baseUrl) throw new Error('遠端未初始化');
+
+    const emitter = new EventEmitter();
+    let stream = null;
+
+    const url = `${baseUrl}/${info.subdomain}/${info.routes.send}`;
+    const payload = { messages, stream: true };
+
+    axios({
+      url,
+      method: 'POST',
+      data: payload,
+      responseType: 'stream',
+      headers: { 'Content-Type': 'application/json' }
+    }).then(res => {
+      stream = res.data;
+      let buffer = '';
+      stream.on('data', chunk => {
+        buffer += chunk.toString();
+        let lines = buffer.split('\n');
+        buffer = lines.pop();
+        for (const line of lines) {
+          if (line.startsWith('data: ')) {
+            const content = line.replace('data: ', '').trim();
+            if (content === '[DONE]') {
+              emitter.emit('end');
+              return;
+            }
+            try {
+              const json = JSON.parse(content);
+              const text = json.text || json.choices?.[0]?.delta?.content || '';
+              emitter.emit('data', text, json);
+            } catch (e) {
+              emitter.emit('error', e);
+            }
+          }
+        }
+      });
+      stream.on('end', () => emitter.emit('end'));
+      stream.on('error', err => emitter.emit('error', err));
+    }).catch(err => emitter.emit('error', err));
+
+    emitter.abort = () => {
+      if (stream && typeof stream.destroy === 'function') {
+        stream.destroy();
+        emitter.emit('abort');
+      }
+    };
+
+    return emitter;
+  }
+};

--- a/src/plugins/llamaServer/strategies/remote/infor.js
+++ b/src/plugins/llamaServer/strategies/remote/infor.js
@@ -1,0 +1,8 @@
+module.exports = {
+  // 子網域名稱，提供給 ngrok 註冊與遠端存取
+  subdomain: 'llama',
+  // 透過遠端存取時，可使用的 API 路由
+  routes: {
+    send: 'send',
+  }
+};

--- a/src/plugins/llamaServer/strategies/server/index.js
+++ b/src/plugins/llamaServer/strategies/server/index.js
@@ -1,0 +1,67 @@
+const local = require('../local');
+const info = require('../remote/infor');
+const pluginsManager = require('../../../../core/pluginsManager');
+const Logger = require('../../../../utils/logger');
+
+const logger = new Logger('LlamaServer');
+let registered = false;
+
+module.exports = {
+  /**
+   * 啟動伺服器模式：啟動本地 Llama 並註冊 ngrok 子網域
+   */
+  async online(options = {}) {
+    await local.online(options);
+
+    const handler = async (req, res) => {
+      if (req.method === 'POST' && req.params.action === info.routes.send) {
+        try {
+          const msgs = Array.isArray(req.body.messages) ? req.body.messages : [];
+          const emitter = await local.send(msgs);
+          res.writeHead(200, {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            Connection: 'keep-alive'
+          });
+          emitter.on('data', txt => res.write(`data: ${JSON.stringify({ text: txt })}\n`));
+          emitter.on('end', () => { res.write('data: [DONE]\n\n'); res.end(); });
+          emitter.on('error', err => { logger.error(err.message); res.status(500).end(); });
+        } catch (e) {
+          logger.error(`處理遠端請求失敗: ${e.message}`);
+          res.status(500).end();
+        }
+      } else {
+        res.status(404).end();
+      }
+    };
+
+    const result = await pluginsManager.send('ngrok', { action: 'register', subdomain: info.subdomain, handler });
+    if (!result) {
+      logger.error('註冊 ngrok 子網域失敗');
+      return false;
+    }
+    registered = true;
+    return true;
+  },
+
+  /** 關閉伺服器並解除註冊 */
+  async offline() {
+    if (registered) {
+      await pluginsManager.send('ngrok', { action: 'unregister', subdomain: info.subdomain });
+      registered = false;
+    }
+    await local.offline();
+    return true;
+  },
+
+  async restart(options) {
+    await this.offline();
+    return this.online(options);
+  },
+
+  async state() {
+    return local.state();
+  },
+
+  send: local.send
+};

--- a/src/plugins/tts/index.js
+++ b/src/plugins/tts/index.js
@@ -1,20 +1,37 @@
 const local = require('./strategies/local');
+const remote = require('./strategies/remote');
+const server = require('./strategies/server');
 const Logger = require('../../utils/logger');
 const logger = new Logger('TTS');
 
 let strategy = null;
+let mode = 'local';
 
 module.exports = {
-  // 更新策略
-  async updateStrategy() {
+  /**
+   * 更新策略模式
+   * @param {'local'|'remote'|'server'} newMode
+   */
+  async updateStrategy(newMode = 'local') {
     logger.info('TTS 插件策略更新中...');
-    strategy = local;
-    logger.info('TTS 插件策略已載入');
+    mode = newMode;
+    switch (newMode) {
+      case 'remote':
+        strategy = remote;
+        break;
+      case 'server':
+        strategy = server;
+        break;
+      default:
+        strategy = local;
+    }
+    logger.info(`TTS 插件策略已切換為 ${mode}`);
   },
 
   // 啟動 TTS
-  async online(options) {
-    if (!strategy) await this.updateStrategy();
+  async online(options = {}) {
+    const useMode = options.mode || mode;
+    if (!strategy || useMode !== mode) await this.updateStrategy(useMode);
     try {
       return await strategy.online(options);
     } catch (e) {
@@ -25,7 +42,7 @@ module.exports = {
 
   // 關閉 TTS
   async offline() {
-    if (!strategy) await this.updateStrategy();
+    if (!strategy) await this.updateStrategy(mode);
     try {
       return await strategy.offline();
     } catch (e) {
@@ -35,8 +52,9 @@ module.exports = {
   },
 
   // 重啟 TTS
-  async restart(options) {
-    if (!strategy) await this.updateStrategy();
+  async restart(options = {}) {
+    const useMode = options.mode || mode;
+    if (!strategy || useMode !== mode) await this.updateStrategy(useMode);
     try {
       return await strategy.restart(options);
     } catch (e) {
@@ -47,7 +65,7 @@ module.exports = {
 
   // 查詢狀態
   async state() {
-    if (!strategy) await this.updateStrategy();
+    if (!strategy) await this.updateStrategy(mode);
     try {
       return await strategy.state();
     } catch (e) {
@@ -58,7 +76,8 @@ module.exports = {
 
   // 選用函式
   async send(data) {
-    if (!strategy || typeof strategy.send !== 'function') {
+    if (!strategy) await this.updateStrategy(mode);
+    if (typeof strategy.send !== 'function') {
       return false;
     }
     return strategy.send(data);

--- a/src/plugins/tts/strategies/remote/index.js
+++ b/src/plugins/tts/strategies/remote/index.js
@@ -1,0 +1,54 @@
+const axios = require('axios');
+const Logger = require('../../../../utils/logger');
+const info = require('./infor');
+
+const logger = new Logger('TTSRemote');
+let baseUrl = '';
+
+module.exports = {
+  /**
+   * 啟動遠端策略
+   * @param {{baseUrl:string}} options
+   */
+  async online(options = {}) {
+    if (!options.baseUrl) {
+      throw new Error('遠端模式需要提供 baseUrl');
+    }
+    baseUrl = options.baseUrl.replace(/\/$/, '');
+    logger.info(`TTS remote 已設定 baseUrl: ${baseUrl}`);
+    return true;
+  },
+
+  /** 關閉遠端策略 */
+  async offline() {
+    baseUrl = '';
+    logger.info('TTS remote 已關閉');
+    return true;
+  },
+
+  /** 重新啟動遠端策略 */
+  async restart(options) {
+    await this.offline();
+    return this.online(options);
+  },
+
+  /** 狀態：有設定 baseUrl 即視為啟用 */
+  async state() {
+    return baseUrl ? 1 : 0;
+  },
+
+  /**
+   * 將文字傳送給遠端伺服器
+   * @param {string} text
+   */
+  async send(text = '') {
+    if (!baseUrl) throw new Error('遠端未初始化');
+    try {
+      await axios.post(`${baseUrl}/${info.subdomain}/${info.routes.send}`, { text });
+      return true;
+    } catch (e) {
+      logger.error('TTS 遠端發送失敗: ' + e.message);
+      throw e;
+    }
+  }
+};

--- a/src/plugins/tts/strategies/remote/infor.js
+++ b/src/plugins/tts/strategies/remote/infor.js
@@ -1,0 +1,6 @@
+module.exports = {
+  subdomain: 'tts',
+  routes: {
+    send: 'send'
+  }
+};

--- a/src/plugins/tts/strategies/server/index.js
+++ b/src/plugins/tts/strategies/server/index.js
@@ -1,0 +1,57 @@
+const local = require('../local');
+const info = require('../remote/infor');
+const pluginsManager = require('../../../../core/pluginsManager');
+const Logger = require('../../../../utils/logger');
+
+const logger = new Logger('TTSServer');
+let registered = false;
+
+module.exports = {
+  /** 啟動伺服器模式並註冊子網域 */
+  async online(options = {}) {
+    await local.online(options);
+
+    const handler = async (req, res) => {
+      if (req.method === 'POST' && req.params.action === info.routes.send) {
+        try {
+          const text = String(req.body.text || '');
+          await local.send(text);
+          return res.status(200).end();
+        } catch (e) {
+          logger.error('處理 TTS 遠端請求失敗: ' + e.message);
+          return res.status(500).end();
+        }
+      }
+      return res.status(404).end();
+    };
+
+    const result = await pluginsManager.send('ngrok', { action: 'register', subdomain: info.subdomain, handler });
+    if (!result) {
+      logger.error('註冊 ngrok 子網域失敗');
+      return false;
+    }
+    registered = true;
+    return true;
+  },
+
+  /** 關閉伺服器並解除註冊 */
+  async offline() {
+    if (registered) {
+      await pluginsManager.send('ngrok', { action: 'unregister', subdomain: info.subdomain });
+      registered = false;
+    }
+    await local.offline();
+    return true;
+  },
+
+  async restart(options) {
+    await this.offline();
+    return this.online(options);
+  },
+
+  async state() {
+    return local.state();
+  },
+
+  send: local.send
+};

--- a/src/tools/fileEditer/index.js
+++ b/src/tools/fileEditer/index.js
@@ -1,7 +1,7 @@
 module.exports = {
     GetFileContent: require('./impl/readFile').GetFileContent,
-    GetFilesContent: require('./impl/ReadDir').GetFilesContent,
+    GetFilesContent: require('./impl/readDir').GetFilesContent,
     writeFile_Cover: require('./impl/coverFile').writeFile_Cover,
-    writeFile_Append: require('./impl/appendfile').writeFile_Append,
+    writeFile_Append: require('./impl/appendFile').writeFile_Append,
     checkFile: require('./utils/checkFile').checkFile
 }


### PR DESCRIPTION
## Summary
- add remote and server logic for asr plugin
- add remote and server logic for tts plugin
- allow asr and tts plugins to switch mode
- document updates in UpdateLog

## Testing
- `npm test` *(fails: ENOENT on llama-server executable and missing presets)*

------
https://chatgpt.com/codex/tasks/task_e_6876f022cac8832f9f6df579883edba5