### PR TITLE
修正遠端設定檔位置並清理索引

### DIFF
--- a/UpdateLog.md
+++ b/UpdateLog.md
@@ -132,3 +132,18 @@
 - 更新所有插件以從所選策略讀取優先度
 - 調整文件說明與 ToDo
 
+### [v.0.7.3]
+## Fix
+- 補上遠端策略遺漏的 infor.js 檔案
+- 修正 LlamaServerManager 策略切換邏輯
+## Test
+- 新增 ASR、TTS、LlamaServer 遠端策略單元測試
+
+### [v.0.7.4]
+## Fix
+- 移除多餘的 remote/infor.js，改由 server 策略提供設定
+- 修正 TTS 插件策略切換錯誤
+## Change
+- ASR、TTS 策略 index.js 匯出三種策略
+- 整理三個插件根目錄 index.js，統一策略載入邏輯
+

--- a/__test__/asrRemote.test.js
+++ b/__test__/asrRemote.test.js
@@ -1,0 +1,33 @@
+const axios = require('axios');
+jest.mock('axios');
+
+const asrRemote = require('../src/plugins/asr/strategies/remote');
+
+describe('ASR 遠端策略', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('online 與 offline 應正常執行', async () => {
+    await expect(asrRemote.online({ baseUrl: 'http://host/' })).resolves.toBe(true);
+    axios.get.mockRejectedValue(new Error('fail'));
+    await asrRemote.state();
+    await expect(asrRemote.offline()).resolves.toBe(true);
+  });
+
+  test('state 會向遠端查詢並回傳狀態', async () => {
+    axios.get.mockResolvedValue({ data: { state: 3 } });
+    await asrRemote.online({ baseUrl: 'http://host' });
+    const state = await asrRemote.state();
+    expect(axios.get).toHaveBeenCalledWith('http://host/asr/state');
+    expect(state).toBe(3);
+  });
+
+  test('send 會根據 action 發送指令', async () => {
+    axios.post.mockResolvedValue({ data: 'ok' });
+    await asrRemote.online({ baseUrl: 'http://host' });
+    const res = await asrRemote.send('start');
+    expect(axios.post).toHaveBeenCalledWith('http://host/asr/start');
+    expect(res).toBe('ok');
+  });
+});

--- a/__test__/llamaRemote.test.js
+++ b/__test__/llamaRemote.test.js
@@ -1,0 +1,32 @@
+const axios = require('axios');
+const { EventEmitter } = require('events');
+jest.mock('axios');
+
+const llamaRemote = require('../src/plugins/llamaServer/strategies/remote');
+
+describe('LlamaServer 遠端策略', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  test('online 之後 state 應為 1', async () => {
+    await llamaRemote.online({ baseUrl: 'http://host' });
+    expect(await llamaRemote.state()).toBe(1);
+  });
+
+  test('send 會處理串流資料', async () => {
+    const stream = new EventEmitter();
+    axios.mockResolvedValue({ data: stream });
+
+    await llamaRemote.online({ baseUrl: 'http://host' });
+    const emitter = await llamaRemote.send([]);
+
+    const chunks = [];
+    emitter.on('data', t => chunks.push(t));
+
+    stream.emit('data', 'data: {"text":"a"}\n');
+    stream.emit('data', 'data: {"text":"b"}\n');
+    stream.emit('data', 'data: [DONE]\n');
+    await new Promise(r => setImmediate(r));
+
+    expect(chunks.join('')).toBe('ab');
+  });
+});

--- a/__test__/ttsRemote.test.js
+++ b/__test__/ttsRemote.test.js
@@ -1,0 +1,27 @@
+const axios = require('axios');
+jest.mock('axios');
+
+const ttsRemote = require('../src/plugins/tts/strategies/remote');
+
+describe('TTS 遠端策略', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  test('online 與 offline 正常執行', async () => {
+    await expect(ttsRemote.online({ baseUrl: 'http://host' })).resolves.toBe(true);
+    await expect(ttsRemote.offline()).resolves.toBe(true);
+  });
+
+  test('send 會傳送文字', async () => {
+    axios.post.mockResolvedValue({});
+    await ttsRemote.online({ baseUrl: 'http://host' });
+    await ttsRemote.send('hi');
+    expect(axios.post).toHaveBeenCalledWith('http://host/tts/send', { text: 'hi' });
+  });
+
+  test('state 根據 baseUrl 決定是否啟用', async () => {
+    await ttsRemote.online({ baseUrl: 'http://host' });
+    expect(await ttsRemote.state()).toBe(1);
+    await ttsRemote.offline();
+    expect(await ttsRemote.state()).toBe(0);
+  });
+});

--- a/src/plugins/asr/index.js
+++ b/src/plugins/asr/index.js
@@ -17,16 +17,8 @@ module.exports = {
   async updateStrategy(newMode = 'local') {
     logger.info('ASR 插件策略更新中...');
     mode = newMode;
-    switch (newMode) {
-      case 'remote':
-        strategy = strategies.remote;
-        break;
-      case 'server':
-        strategy = strategies.server;
-        break;
-      default:
-        strategy = strategies.local;
-    }
+    // 依傳入模式選擇對應策略，預設 local
+    strategy = strategies[newMode] || strategies.local;
     // 依據所選策略設定優先度
     this.priority = strategy.priority;
     logger.info(`ASR 插件策略已切換為 ${mode}`);

--- a/src/plugins/asr/strategies/index.js
+++ b/src/plugins/asr/strategies/index.js
@@ -1,6 +1,10 @@
 const local = require('./local');
+const remote = require('./remote');
+const server = require('./server');
 
-// 匯出各策略實作
+// 匯出各策略實作，提供給插件選擇
 module.exports = {
   local,
+  remote,
+  server
 };

--- a/src/plugins/asr/strategies/remote/index.js
+++ b/src/plugins/asr/strategies/remote/index.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const Logger = require('../../../../utils/logger');
-const info = require('./infor');
+// 改為直接引用 server 策略的設定
+const info = require('../server/infor');
 
 const logger = new Logger('ASRRemote');
 let baseUrl = '';

--- a/src/plugins/llamaServer/index.js
+++ b/src/plugins/llamaServer/index.js
@@ -4,7 +4,8 @@ const strategies = require('./strategies');
 const Logger = require('../../utils/logger');
 const logger = new Logger('LlamaServerManager');
 
-let strategy = null;
+// 目前使用中的策略，預設採用 local
+let strategy = strategies.local;
 let mode = 'local';
 
 
@@ -19,20 +20,10 @@ module.exports = {
     async updateStrategy(newMode = 'local') {
         logger.info('LlamaServerManager 更新策略中...');
         mode = newMode;
-        switch (newMode) {
-            case 'remote':
-                strategies = remote;
-                break;
-            case 'server':
-                strategies = server;
-                break;
-            default:
-                strategies = local;
-        }
-        logger.info(`LlamaServerManager 策略已切換為 ${mode}`);
-        // 這裡可以根據需要更新策略，目前僅支援 local 策略
-        strategy = strategies.local;
+        // 依傳入模式選擇對應策略，預設為 local
+        strategy = strategies[newMode] || strategies.local;
         this.priority = strategy.priority;
+        logger.info(`LlamaServerManager 策略已切換為 ${mode}`);
         logger.info('LlamaServerManager 策略更新完成');
     },
 
@@ -74,6 +65,6 @@ module.exports = {
             await this.updateStrategy();
         }
         return await strategy.send(options);
-    },
-    
-}
+    }
+
+};

--- a/src/plugins/llamaServer/strategies/index.js
+++ b/src/plugins/llamaServer/strategies/index.js
@@ -1,7 +1,10 @@
 const local = require('./local');
 const remote = require('./remote');
+const server = require('./server');
 
+// 將三種策略集中導出，供管理器選擇
 module.exports = {
   local,
   remote,
+  server
 };

--- a/src/plugins/llamaServer/strategies/remote/index.js
+++ b/src/plugins/llamaServer/strategies/remote/index.js
@@ -1,7 +1,8 @@
 const axios = require('axios');
 const EventEmitter = require('events');
 const Logger = require('../../../../utils/logger');
-const info = require('./infor');
+// 改為直接引用 server 策略的設定
+const info = require('../server/infor');
 
 const logger = new Logger('LlamaRemote');
 

--- a/src/plugins/tts/index.js
+++ b/src/plugins/tts/index.js
@@ -16,16 +16,8 @@ module.exports = {
   async updateStrategy(newMode = 'local') {
     logger.info('TTS 插件策略更新中...');
     mode = newMode;
-    switch (newMode) {
-      case 'remote':
-        strategy = remote;
-        break;
-      case 'server':
-        strategy = server;
-        break;
-      default:
-        strategy = strategies.local;
-    }
+    // 依傳入模式選擇對應策略，預設 local
+    strategy = strategies[newMode] || strategies.local;
     this.priority = strategy.priority;
     logger.info(`TTS 插件策略已切換為 ${mode}`);
   },

--- a/src/plugins/tts/strategies/index.js
+++ b/src/plugins/tts/strategies/index.js
@@ -1,5 +1,10 @@
 const local = require('./local');
+const remote = require('./remote');
+const server = require('./server');
 
+// 匯出三種策略以供插件載入
 module.exports = {
   local,
+  remote,
+  server
 };

--- a/src/plugins/tts/strategies/remote/index.js
+++ b/src/plugins/tts/strategies/remote/index.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const Logger = require('../../../../utils/logger');
-const info = require('./infor');
+// 改為直接引用 server 策略的設定
+const info = require('../server/infor');
 
 const logger = new Logger('TTSRemote');
 let baseUrl = '';


### PR DESCRIPTION
## Summary
- 移除各插件 remote/infor.js，改由 server 策略提供資訊
- asr、tts 策略索引新增 remote 與 server
- 修正 ASR、TTS 插件策略切換邏輯
- 清理 LlamaServerManager 末端多餘逗號
- 更新 0.7.4 更新紀錄

## Testing
- `npm test` *(fails: spawn /workspace/Demon/Server/llama/llama_cpp_bin/llama-server.exe ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_687a54c3f25c832fb6601fd2f2f635fd