### PR TITLE
完善工具路由對 JSON 代碼區塊的處理

### DIFF
--- a/__test__/toolOutputRouter.test.js
+++ b/__test__/toolOutputRouter.test.js
@@ -108,3 +108,33 @@ describe('toolOutputRouter JSON 字串包含 Markdown', () => {
     }
   });
 });
+
+describe('toolOutputRouter 文字含三重反引號', () => {
+  test('非 JSON 的 ``` 不應阻擋輸出', async () => {
+    expect.assertions(2);
+    try {
+      const res = await routeOutput('Use ``` to start a code block.');
+
+      expect(res.handled).toBe(false);
+      expect(res.content).toBe('Use ``` to start a code block.');
+    } catch (e) {
+      console.error('測試失敗:', e);
+      throw e;
+    }
+  });
+});
+
+describe('toolOutputRouter 非工具 JSON', () => {
+  test('未閉合的 JSON 代碼區塊應直接輸出', async () => {
+    expect.assertions(2);
+    try {
+      const res = await routeOutput('```json\n{"foo":1}');
+
+      expect(res.handled).toBe(false);
+      expect(res.content).toBe('```json\n{"foo":1}');
+    } catch (e) {
+      console.error('測試失敗:', e);
+      throw e;
+    }
+  });
+});

--- a/src/core/toolOutputRouter.js
+++ b/src/core/toolOutputRouter.js
@@ -113,9 +113,35 @@ function backtickState(str) {
   let lastOpenIndex = -1;
   for (let i = 0; i < str.length - 2; i++) {
     if (str.slice(i, i + 3) === '```') {
-      if (!inCode) lastOpenIndex = i;
-      inCode = !inCode;
+      if (!inCode) {
+        // 檢查後續是否為 JSON（允許 "```json" 或直接接著 "{"）
+        const after  = str.slice(i + 3);
+        const match  = after.match(/^([a-zA-Z]*)[\t\r\n ]*/); // 取得語言標記
+        const lang   = (match && match[1] || '').toLowerCase();
+        const rest   = after.slice(match ? match[0].length : 0).trimStart();
+        if ((lang === '' || lang === 'json') && rest.startsWith('{')) {
+          inCode = true;
+          lastOpenIndex = i;
+        }
+      } else {
+        // 已在代碼區塊中，遇到結束反引號時關閉
+        inCode = false;
+      }
       i += 2;
+    }
+  }
+  // 若仍在 JSON 代碼區塊內，檢查內容是否為非工具的完整 JSON
+  if (inCode) {
+    try {
+      const after = str.slice(lastOpenIndex + 3);
+      const match = after.match(/^([a-zA-Z]*)[\t\r\n ]*/); // 語言標記
+      const rest  = after.slice(match ? match[0].length : 0);
+      const trimmed = rest.trim();
+      const tool = findToolJSON(trimmed);
+      JSON.parse(trimmed); // 若解析失敗，將落入 catch
+      if (!tool) inCode = false; // 非工具 JSON，放行
+    } catch (_) {
+      // 保留 inCode 狀態，等待後續資料補齊
     }
   }
   return { inCode, lastOpenIndex };


### PR DESCRIPTION
## 摘要
- 忽略不含 JSON 的三重反引號，避免誤判為代碼區塊
- 未閉合但內容為非工具的 JSON 代碼區塊直接輸出
- 新增對應單元測試

## 測試
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4337718c4832fa613f435ea9630fe